### PR TITLE
Fix flower binding range not being centered at spreader/pool.

### DIFF
--- a/src/main/java/vazkii/botania/api/subtile/TileEntityFunctionalFlower.java
+++ b/src/main/java/vazkii/botania/api/subtile/TileEntityFunctionalFlower.java
@@ -214,11 +214,11 @@ public class TileEntityFunctionalFlower extends TileEntitySpecialFlower {
 
 	@Override
 	public boolean bindTo(PlayerEntity player, ItemStack wand, BlockPos pos, Direction side) {
-		int range = 10;
-		range *= range;
+		double sqRange = (LINK_RANGE + 0.5) * (LINK_RANGE + 0.5);
 
-		double dist = pos.distanceSq(getPos());
-		if (range >= dist) {
+		BlockPos flower = getPos();
+		double dist = pos.distanceSq(flower.getX(), flower.getY(), flower.getZ(), false);
+		if (sqRange >= dist) {
 			TileEntity tile = player.world.getTileEntity(pos);
 			if (tile instanceof IManaPool) {
 				linkedPool = tile;

--- a/src/main/java/vazkii/botania/api/subtile/TileEntityGeneratingFlower.java
+++ b/src/main/java/vazkii/botania/api/subtile/TileEntityGeneratingFlower.java
@@ -247,11 +247,11 @@ public class TileEntityGeneratingFlower extends TileEntitySpecialFlower {
 
 	@Override
 	public boolean bindTo(PlayerEntity player, ItemStack wand, BlockPos pos, Direction side) {
-		int range = 6;
-		range *= range;
+		double sqRange = (LINK_RANGE + 0.5) * (LINK_RANGE + 0.5);
 
-		double dist = pos.distanceSq(getPos());
-		if (range >= dist) {
+		BlockPos flower = getPos();
+		double dist = pos.distanceSq(flower.getX(), flower.getY(), flower.getZ(), false);
+		if (sqRange >= dist) {
 			TileEntity tile = player.world.getTileEntity(pos);
 			if (tile instanceof IManaCollector) {
 				linkedCollector = tile;

--- a/src/main/java/vazkii/botania/common/core/handler/ManaNetworkHandler.java
+++ b/src/main/java/vazkii/botania/common/core/handler/ManaNetworkHandler.java
@@ -77,10 +77,11 @@ public final class ManaNetworkHandler implements IManaNetwork {
 		double minDist = Double.MAX_VALUE;
 		TileEntity closest = null;
 
+		double sqLimit = (limit + 0.5) * (limit + 0.5);
 		for (TileEntity te : tiles) {
 			if (!te.isRemoved()) {
-				double distance = te.getPos().distanceSq(pos);
-				if (distance <= limit * limit && distance < minDist) {
+				double distance = te.getPos().distanceSq(pos.getX(), pos.getY(), pos.getZ(), false);
+				if (distance <= sqLimit && distance < minDist) {
 					minDist = distance;
 					closest = te;
 				}

--- a/src/main/java/vazkii/botania/common/item/ItemObedienceStick.java
+++ b/src/main/java/vazkii/botania/common/item/ItemObedienceStick.java
@@ -45,10 +45,11 @@ public class ItemObedienceStick extends Item {
 			boolean pool = tileAt instanceof IManaPool;
 			BiFunction<TileEntitySpecialFlower, TileEntity, Boolean> act = pool ? functionalActuator : generatingActuator;
 			int range = pool ? TileEntityFunctionalFlower.LINK_RANGE : TileEntityGeneratingFlower.LINK_RANGE;
+			double sqRange = (range + 0.5) * (range + 0.5);
 
 			for (BlockPos iterPos : BlockPos.getAllInBoxMutable(pos.add(-range, -range, -range),
 					pos.add(range, range, range))) {
-				if (iterPos.distanceSq(pos) > range * range) {
+				if (iterPos.distanceSq(pos.getX(), pos.getY(), pos.getZ(), false) > sqRange) {
 					continue;
 				}
 


### PR DESCRIPTION
Fixes #3775 

So basically the previously used method
BlockPos#distanceSq(BlockPos)
would center the coordinates (add 0.5) of the variable the method has been called on, but not of the passed parameter. That lead to the resulting binding range being shifted.

Calling
BlockPos#distanceSq(x, y, z, boolean center)
instead, allows to specify whether the coordinates should be centered or not.

Adding 0.5 to the range before squaring makes the resulting binding range a nice and clean circle, instead of a circle with dots on the flat sides (dunno how to describe it better).