### PR TITLE
Fire LivingJumpEvent on server to fix #3495

### DIFF
--- a/src/main/java/vazkii/botania/common/network/PacketJump.java
+++ b/src/main/java/vazkii/botania/common/network/PacketJump.java
@@ -32,6 +32,7 @@ public class PacketJump {
 
 				ItemStack amuletStack = EquipmentHandler.findOrEmpty(s -> s.getItem() instanceof ItemCloudPendant, player);
 				if (!amuletStack.isEmpty()) {
+					net.minecraftforge.common.ForgeHooks.onLivingJump(player);
 					player.addExhaustion(0.3F);
 					player.fallDistance = 0;
 					ItemCloudPendant.setJumping(player);


### PR DESCRIPTION
Currently the living jump isnt fired when player uses Cirrus / Nimbus Amulet to double/triple jump. This issue is fixed by firing the event on server when the amulet is used.