### PR TITLE
Make the corporea index look better (+ some other stuff)

### DIFF
--- a/src/generated/resources/assets/botania/models/block/corporea_index.json
+++ b/src/generated/resources/assets/botania/models/block/corporea_index.json
@@ -1,5 +1,5 @@
 {
   "textures": {
-    "particle": "botania:block/elementium_block"
+    "particle": "botania:block/corporea_block"
   }
 }

--- a/src/main/java/vazkii/botania/client/render/tile/RenderTileCorporeaIndex.java
+++ b/src/main/java/vazkii/botania/client/render/tile/RenderTileCorporeaIndex.java
@@ -45,17 +45,17 @@ public class RenderTileCorporeaIndex extends TileEntityRenderer<TileCorporeaInde
 	public void render(@Nullable TileCorporeaIndex index, float partialTicks, MatrixStack ms, IRenderTypeBuffer buffers, int light, int overlay) {
 		ms.push();
 		ms.translate(0.5, 0, 0.5);
-		
+
 		float rotation = (ClientTickHandler.ticksInGame + partialTicks) * 2;
 		float translation;
-		if(index == null) { //TEISR
+		if (index == null) { //TEISR
 			ms.scale(1.3f, 1.3f, 1.3f);
 			ms.translate(0, -0.1, 0);
 			translation = 0;
 		} else {
 			translation = (float) ((Math.cos((index.ticksWithCloseby + (index.hasCloseby ? partialTicks : 0)) / 10F) * 0.5 + 0.5) * 0.25);
 		}
-		
+
 		IVertexBuilder buffer = buffers.getBuffer(LAYER);
 		ms.push();
 		ms.translate(0.0D, -1, 0.0D);

--- a/src/main/java/vazkii/botania/client/render/tile/RenderTileCorporeaIndex.java
+++ b/src/main/java/vazkii/botania/client/render/tile/RenderTileCorporeaIndex.java
@@ -20,6 +20,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.vector.Quaternion;
 import net.minecraft.util.math.vector.Vector3f;
 
+import vazkii.botania.client.core.handler.ClientTickHandler;
 import vazkii.botania.client.core.helper.RenderHelper;
 import vazkii.botania.client.lib.LibResources;
 import vazkii.botania.common.block.tile.corporea.TileCorporeaIndex;
@@ -44,8 +45,17 @@ public class RenderTileCorporeaIndex extends TileEntityRenderer<TileCorporeaInde
 	public void render(@Nullable TileCorporeaIndex index, float partialTicks, MatrixStack ms, IRenderTypeBuffer buffers, int light, int overlay) {
 		ms.push();
 		ms.translate(0.5, 0, 0.5);
-		float translation = index != null ? (float) ((Math.cos((index.ticksWithCloseby + (index.hasCloseby ? partialTicks : 0)) / 10F) * 0.5 + 0.5) * 0.25) : 0F;
-		float rotation = index != null ? index.ticks * 2 + partialTicks : 0F;
+		
+		float rotation = (ClientTickHandler.ticksInGame + partialTicks) * 2;
+		float translation;
+		if(index == null) { //TEISR
+			ms.scale(1.3f, 1.3f, 1.3f);
+			ms.translate(0, -0.1, 0);
+			translation = 0;
+		} else {
+			translation = (float) ((Math.cos((index.ticksWithCloseby + (index.hasCloseby ? partialTicks : 0)) / 10F) * 0.5 + 0.5) * 0.25);
+		}
+		
 		IVertexBuilder buffer = buffers.getBuffer(LAYER);
 		ms.push();
 		ms.translate(0.0D, -1, 0.0D);

--- a/src/main/java/vazkii/botania/client/render/tile/TEISR.java
+++ b/src/main/java/vazkii/botania/client/render/tile/TEISR.java
@@ -22,6 +22,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.LazyValue;
 import net.minecraft.util.registry.Registry;
+import vazkii.botania.client.core.handler.ClientTickHandler;
 
 public class TEISR extends ItemStackTileEntityRenderer {
 	private final Block block;
@@ -40,7 +41,7 @@ public class TEISR extends ItemStackTileEntityRenderer {
 		if (stack.getItem() == block.asItem()) {
 			TileEntityRenderer<?> r = TileEntityRendererDispatcher.instance.getRenderer(dummy.getValue());
 			if (r != null) {
-				r.render(null, 0, ms, buffers, light, overlay);
+				r.render(null, ClientTickHandler.partialTicks, ms, buffers, light, overlay);
 			}
 		}
 	}

--- a/src/main/java/vazkii/botania/client/render/tile/TEISR.java
+++ b/src/main/java/vazkii/botania/client/render/tile/TEISR.java
@@ -22,6 +22,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.LazyValue;
 import net.minecraft.util.registry.Registry;
+
 import vazkii.botania.client.core.handler.ClientTickHandler;
 
 public class TEISR extends ItemStackTileEntityRenderer {

--- a/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaIndex.java
+++ b/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaIndex.java
@@ -11,6 +11,10 @@ package vazkii.botania.common.block.corporea;
 import net.minecraft.block.BlockRenderType;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.ITileEntityProvider;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.shapes.ISelectionContext;
+import net.minecraft.util.math.shapes.VoxelShape;
+import net.minecraft.util.math.shapes.VoxelShapes;
 import net.minecraft.world.IBlockReader;
 
 import vazkii.botania.common.block.BlockModWaterloggable;
@@ -20,8 +24,16 @@ import vazkii.botania.common.block.tile.corporea.TileCorporeaIndex;
 import javax.annotation.Nonnull;
 
 public class BlockCorporeaIndex extends BlockModWaterloggable implements ITileEntityProvider {
+	private static final VoxelShape SHAPE = makeCuboidShape(2, 2, 2, 14, 14, 14);
+
 	public BlockCorporeaIndex(Properties builder) {
 		super(builder);
+	}
+	
+	@Nonnull
+	@Override
+	public VoxelShape getShape(BlockState state, IBlockReader worldIn, BlockPos pos, ISelectionContext context) {
+		return SHAPE;
 	}
 
 	@Nonnull

--- a/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaIndex.java
+++ b/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaIndex.java
@@ -14,7 +14,6 @@ import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
-import net.minecraft.util.math.shapes.VoxelShapes;
 import net.minecraft.world.IBlockReader;
 
 import vazkii.botania.common.block.BlockModWaterloggable;
@@ -29,7 +28,7 @@ public class BlockCorporeaIndex extends BlockModWaterloggable implements ITileEn
 	public BlockCorporeaIndex(Properties builder) {
 		super(builder);
 	}
-	
+
 	@Nonnull
 	@Override
 	public VoxelShape getShape(BlockState state, IBlockReader worldIn, BlockPos pos, ISelectionContext context) {

--- a/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaIndex.java
+++ b/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaIndex.java
@@ -307,14 +307,14 @@ public class TileCorporeaIndex extends TileCorporeaBase implements ICorporeaRequ
 		super.onChunkUnloaded();
 		removeIndex(this);
 	}
-	
+
 	@OnlyIn(Dist.CLIENT)
 	@Override
 	public AxisAlignedBB getRenderBoundingBox() {
 		//The tile entity renderer can draw pink stars fairly far away from the index itself, this helps it not get culled too early.
 		return new AxisAlignedBB(pos.add(-2, 0, -2), pos.add(3, 1, 3));
 	}
-	
+
 	@Override
 	public void doCorporeaRequest(ICorporeaRequestMatcher request, int count, ICorporeaSpark spark) {
 		doRequest(request, count, spark);

--- a/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaIndex.java
+++ b/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaIndex.java
@@ -17,6 +17,8 @@ import net.minecraft.util.Util;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.TranslationTextComponent;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ServerChatEvent;
 
@@ -305,7 +307,14 @@ public class TileCorporeaIndex extends TileCorporeaBase implements ICorporeaRequ
 		super.onChunkUnloaded();
 		removeIndex(this);
 	}
-
+	
+	@OnlyIn(Dist.CLIENT)
+	@Override
+	public AxisAlignedBB getRenderBoundingBox() {
+		//The tile entity renderer can draw pink stars fairly far away from the index itself, this helps it not get culled too early.
+		return new AxisAlignedBB(pos.add(-2, 0, -2), pos.add(3, 1, 3));
+	}
+	
 	@Override
 	public void doCorporeaRequest(ICorporeaRequestMatcher request, int count, ICorporeaSpark spark) {
 		doRequest(request, count, spark);

--- a/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaIndex.java
+++ b/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaIndex.java
@@ -256,7 +256,6 @@ public class TileCorporeaIndex extends TileCorporeaBase implements ICorporeaRequ
 		});
 	}
 
-	public int ticks = 0;
 	public int ticksWithCloseby = 0;
 	public float closeby = 0F;
 	public boolean hasCloseby;
@@ -281,7 +280,6 @@ public class TileCorporeaIndex extends TileCorporeaBase implements ICorporeaRequ
 		}
 
 		float step = 0.2F;
-		ticks++;
 		if (hasCloseby) {
 			ticksWithCloseby++;
 			if (closeby < 1F) {

--- a/src/main/java/vazkii/botania/data/BlockstateProvider.java
+++ b/src/main/java/vazkii/botania/data/BlockstateProvider.java
@@ -249,7 +249,7 @@ public class BlockstateProvider extends BlockStateProvider {
 		particleOnly(remainingBlocks, avatar, prefix("block/livingwood"));
 		particleOnly(remainingBlocks, bellows, prefix("block/livingwood"));
 		particleOnly(remainingBlocks, brewery, prefix("block/livingrock"));
-		particleOnly(remainingBlocks, corporeaIndex, prefix("block/elementium_block"));
+		particleOnly(remainingBlocks, corporeaIndex, prefix("block/corporea_block"));
 		particleOnly(remainingBlocks, lightRelayDetector, prefix("block/detector_light_relay"));
 		simpleBlock(fakeAir, models().getBuilder(Registry.BLOCK.getKey(ModBlocks.fakeAir).getPath()));
 		remainingBlocks.remove(fakeAir);

--- a/src/main/resources/assets/botania/models/block/corporea_crystal_cube.json
+++ b/src/main/resources/assets/botania/models/block/corporea_crystal_cube.json
@@ -3,7 +3,7 @@
 	"textures": {
 		"cloth": "botania:block/corporea_crystal_cube_cloth",
 		"base": "botania:block/corporea_crystal_cube_base",
-		"particle": "botania:block/corporea_crystal_cube_base"
+		"particle": "botania:block/corporea_crystal_cube_cloth"
 	},
 	"elements": [ 	 
 		{


### PR DESCRIPTION
* Fix the math in `RenderTileCorporeaIndex` to add `partialTicks` to the global tick count *before* multiplying it by 2, this makes it not jitter so much
* Pass `ClientTickHandler.partialTicks` through in `TEISR`, everything that uses it now animates smoother. The Botanical Brewery looks a lot nicer now
* Allow the corporea index TEISR to rotate as well. Why not?
* Add a custom render bounding box to the corporea index, so the pink particles don't get prematurely culled when looking away. (I think this method is a forge extension unfortunately)
* Use more fitting particle textures for the corporea index (and corporea crystal cube) since it was bugging me

Also I wanted to fix the AO acting strange on corporea indices (try placing 9 of them in a square, it makes the floor turn black), but I couldn't figure out a better way than just giving them a non-full collision box. I thought the old collision box was kind of big anyways lol