### PR TITLE
Fixed the issue with the built jar

### DIFF
--- a/src/main/java/vazkii/botania/mixin/MixinDetectorRailBlock.java
+++ b/src/main/java/vazkii/botania/mixin/MixinDetectorRailBlock.java
@@ -36,7 +36,7 @@ public class MixinDetectorRailBlock {
 	// Target: before the check for container carts
 	@Inject(
 		method = "getAnalogOutputSignal", cancellable = true, at = @At(
-			value = "CONSTANT", ordinal = 0, args = "classValue=net/minecraft/world/entity/vehicle/AbstractMinecart"
+			value = "INVOKE", target = "Lnet/minecraft/world/level/block/DetectorRailBlock;getInteractingMinecartOfType(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Ljava/lang/Class;Ljava/util/function/Predicate;)Ljava/util/List;", ordinal = 1
 		)
 	)
 	private void getManaCartOutputSignal(BlockState state, Level level, BlockPos pos, CallbackInfoReturnable<Integer> cir) {


### PR DESCRIPTION
This fixes the mixin responsible for crashing the game at startup with built jars. This doesn't happen in dev environments, only with a built jar. I tested to ensure the behaviour is still correct.