### PR TITLE
Redo flower-binding logic, remove flower.forceCheck

### DIFF
--- a/src/main/java/vazkii/botania/api/BotaniaAPI.java
+++ b/src/main/java/vazkii/botania/api/BotaniaAPI.java
@@ -296,8 +296,9 @@ public interface BotaniaAPI {
 	default void sparkleFX(World world, double x, double y, double z, float r, float g, float b, float size, int m) {}
 
 	/**
-	 * See config value "flower.forceCheck" for more information
+	 * Deprecated - the flower.forceCheck option has been removed.
 	 */
+	@Deprecated
 	default boolean shouldForceCheck() {
 		return false;
 	}

--- a/src/main/java/vazkii/botania/api/BotaniaAPI.java
+++ b/src/main/java/vazkii/botania/api/BotaniaAPI.java
@@ -300,7 +300,7 @@ public interface BotaniaAPI {
 	 */
 	@Deprecated
 	default boolean shouldForceCheck() {
-		return false;
+		return true;
 	}
 
 	default void registerCorporeaNodeDetector(ICorporeaNodeDetector detector) {

--- a/src/main/java/vazkii/botania/api/subtile/TileEntityFunctionalFlower.java
+++ b/src/main/java/vazkii/botania/api/subtile/TileEntityFunctionalFlower.java
@@ -163,8 +163,9 @@ public class TileEntityFunctionalFlower extends TileEntitySpecialFlower {
 		if (cmp.contains(TAG_POOL_X)) {
 			poolCoordinates = new BlockPos(cmp.getInt(TAG_POOL_X), cmp.getInt(TAG_POOL_Y), cmp.getInt(TAG_POOL_Z));
 			//Older versions of the mod sometimes used this to denote an unbound pool.
-			if (poolCoordinates.getY() == -1)
+			if (poolCoordinates.getY() == -1) {
 				poolCoordinates = null;
+			}
 		}
 
 		if (!Objects.equals(this.poolCoordinates, poolCoordinates)) {

--- a/src/main/java/vazkii/botania/api/subtile/TileEntityFunctionalFlower.java
+++ b/src/main/java/vazkii/botania/api/subtile/TileEntityFunctionalFlower.java
@@ -50,10 +50,9 @@ public class TileEntityFunctionalFlower extends TileEntitySpecialFlower {
 	private int mana;
 
 	public int redstoneSignal = 0;
-
-	TileEntity linkedPool = null;
-
+	
 	private @Nullable BlockPos poolCoordinates = null;
+	private @Nullable TileEntity linkedPool = null;
 
 	public TileEntityFunctionalFlower(TileEntityType<?> type) {
 		super(type);

--- a/src/main/java/vazkii/botania/api/subtile/TileEntityFunctionalFlower.java
+++ b/src/main/java/vazkii/botania/api/subtile/TileEntityFunctionalFlower.java
@@ -127,7 +127,7 @@ public class TileEntityFunctionalFlower extends TileEntitySpecialFlower {
 
 	public boolean wouldBeValidBinding(@Nullable BlockPos pos) {
 		//Same caveat as in TileEntityGeneratingFlower#wouldBeValidBinding -quat
-		if (world == null || pos == null || !world.isBlockLoaded(pos) || pos.distanceSq(this.pos) > 10 * 10) {
+		if (world == null || pos == null || !world.isBlockLoaded(pos) || pos.distanceSq(this.pos) > LINK_RANGE * LINK_RANGE) {
 			return false;
 		} else {
 			return findPoolAt(pos) != null;

--- a/src/main/java/vazkii/botania/api/subtile/TileEntityFunctionalFlower.java
+++ b/src/main/java/vazkii/botania/api/subtile/TileEntityFunctionalFlower.java
@@ -127,7 +127,7 @@ public class TileEntityFunctionalFlower extends TileEntitySpecialFlower {
 
 	public boolean wouldBeValidBinding(@Nullable BlockPos pos) {
 		//Same caveat as in TileEntityGeneratingFlower#wouldBeValidBinding -quat
-		if (world == null || pos == null || !world.isBlockLoaded(pos) || pos.distanceSq(this.pos) > LINK_RANGE * LINK_RANGE) {
+		if (world == null || pos == null || !world.isBlockLoaded(pos) || vazkii.botania.common.core.helper.MathHelper.distanceSq(this.pos, pos) > LINK_RANGE * LINK_RANGE) {
 			return false;
 		} else {
 			return findPoolAt(pos) != null;

--- a/src/main/java/vazkii/botania/api/subtile/TileEntityFunctionalFlower.java
+++ b/src/main/java/vazkii/botania/api/subtile/TileEntityFunctionalFlower.java
@@ -28,10 +28,10 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.api.BotaniaAPIClient;
 import vazkii.botania.api.internal.IManaNetwork;
-import vazkii.botania.api.mana.IManaCollector;
 import vazkii.botania.api.mana.IManaPool;
 
 import javax.annotation.Nullable;
+
 import java.util.Objects;
 
 /**
@@ -50,7 +50,7 @@ public class TileEntityFunctionalFlower extends TileEntitySpecialFlower {
 	private int mana;
 
 	public int redstoneSignal = 0;
-	
+
 	private @Nullable BlockPos poolCoordinates = null;
 	private @Nullable TileEntity linkedPool = null;
 
@@ -101,19 +101,19 @@ public class TileEntityFunctionalFlower extends TileEntitySpecialFlower {
 	}
 
 	public void linkPool() {
-		if(ticksExisted == 1) {
+		if (ticksExisted == 1) {
 			IManaNetwork network = BotaniaAPI.instance().getManaNetworkInstance();
 			linkedPool = network.getClosestPool(getPos(), getWorld(), LINK_RANGE);
 		}
-		
-		if(poolCoordinates != null && getWorld().isBlockLoaded(poolCoordinates)) {
+
+		if (poolCoordinates != null && getWorld().isBlockLoaded(poolCoordinates)) {
 			TileEntity linkedTo = getWorld().getTileEntity(poolCoordinates);
-			if(linkedTo instanceof IManaPool) {
+			if (linkedTo instanceof IManaPool) {
 				linkedPool = linkedTo;
 			}
 		}
-		
-		if(linkedPool != null && linkedPool.isRemoved()) {
+
+		if (linkedPool != null && linkedPool.isRemoved()) {
 			linkedPool = null;
 		}
 	}
@@ -160,16 +160,17 @@ public class TileEntityFunctionalFlower extends TileEntitySpecialFlower {
 		mana = cmp.getInt(TAG_MANA);
 
 		BlockPos poolCoordinates = null;
-		if(cmp.contains(TAG_POOL_X)) {
+		if (cmp.contains(TAG_POOL_X)) {
 			poolCoordinates = new BlockPos(cmp.getInt(TAG_POOL_X), cmp.getInt(TAG_POOL_Y), cmp.getInt(TAG_POOL_Z));
 			//Older versions of the mod sometimes used this to denote an unbound pool.
-			if(poolCoordinates.getY() == -1) poolCoordinates = null;
+			if (poolCoordinates.getY() == -1)
+				poolCoordinates = null;
 		}
-		
+
 		if (!Objects.equals(this.poolCoordinates, poolCoordinates)) {
 			linkedPool = null; //Force a refresh of the linked pool
 		}
-		
+
 		this.poolCoordinates = poolCoordinates;
 	}
 

--- a/src/main/java/vazkii/botania/api/subtile/TileEntityFunctionalFlower.java
+++ b/src/main/java/vazkii/botania/api/subtile/TileEntityFunctionalFlower.java
@@ -104,6 +104,10 @@ public class TileEntityFunctionalFlower extends TileEntitySpecialFlower {
 		if (ticksExisted == 1) {
 			IManaNetwork network = BotaniaAPI.instance().getManaNetworkInstance();
 			linkedPool = network.getClosestPool(getPos(), getWorld(), LINK_RANGE);
+			if (linkedPool != null) {
+				poolCoordinates = linkedPool.getPos();
+			}
+			markDirty();
 		}
 
 		if (poolCoordinates != null && getWorld().isBlockLoaded(poolCoordinates)) {

--- a/src/main/java/vazkii/botania/api/subtile/TileEntityGeneratingFlower.java
+++ b/src/main/java/vazkii/botania/api/subtile/TileEntityGeneratingFlower.java
@@ -16,7 +16,6 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
-import net.minecraft.nbt.NBTUtil;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.Direction;
@@ -33,6 +32,7 @@ import vazkii.botania.api.internal.IManaNetwork;
 import vazkii.botania.api.mana.IManaCollector;
 
 import javax.annotation.Nullable;
+
 import java.util.Objects;
 
 /**
@@ -107,19 +107,19 @@ public class TileEntityGeneratingFlower extends TileEntitySpecialFlower {
 	}
 
 	public void linkCollector() {
-		if(ticksExisted == 1) {
+		if (ticksExisted == 1) {
 			IManaNetwork network = BotaniaAPI.instance().getManaNetworkInstance();
 			linkedCollector = network.getClosestCollector(getPos(), getWorld(), LINK_RANGE);
 		}
-		
-		if(collectorCoordinates != null && getWorld().isBlockLoaded(collectorCoordinates)) {
+
+		if (collectorCoordinates != null && getWorld().isBlockLoaded(collectorCoordinates)) {
 			TileEntity linkedTo = getWorld().getTileEntity(collectorCoordinates);
-			if(linkedTo instanceof IManaCollector) {
+			if (linkedTo instanceof IManaCollector) {
 				linkedCollector = linkedTo;
 			}
 		}
-		
-		if(linkedCollector != null && linkedCollector.isRemoved()) {
+
+		if (linkedCollector != null && linkedCollector.isRemoved()) {
 			linkedCollector = null;
 		}
 	}
@@ -195,16 +195,17 @@ public class TileEntityGeneratingFlower extends TileEntitySpecialFlower {
 		passiveDecayTicks = cmp.getInt(TAG_PASSIVE_DECAY_TICKS);
 
 		BlockPos collectorCoordinates = null;
-		if(cmp.contains(TAG_COLLECTOR_X)) {
+		if (cmp.contains(TAG_COLLECTOR_X)) {
 			collectorCoordinates = new BlockPos(cmp.getInt(TAG_COLLECTOR_X), cmp.getInt(TAG_COLLECTOR_Y), cmp.getInt(TAG_COLLECTOR_Z));
 			//Older versions of the mod sometimes used this to denote an unbound collector.
-			if(collectorCoordinates.getY() == -1) collectorCoordinates = null;
+			if (collectorCoordinates.getY() == -1)
+				collectorCoordinates = null;
 		}
-		
+
 		if (!Objects.equals(this.collectorCoordinates, collectorCoordinates)) {
 			linkedCollector = null; //Force a refresh of the linked collector
 		}
-		
+
 		this.collectorCoordinates = collectorCoordinates;
 	}
 

--- a/src/main/java/vazkii/botania/api/subtile/TileEntityGeneratingFlower.java
+++ b/src/main/java/vazkii/botania/api/subtile/TileEntityGeneratingFlower.java
@@ -30,6 +30,7 @@ import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.api.BotaniaAPIClient;
 import vazkii.botania.api.internal.IManaNetwork;
 import vazkii.botania.api.mana.IManaCollector;
+import vazkii.botania.common.core.helper.MathHelper;
 
 import javax.annotation.Nullable;
 
@@ -146,7 +147,7 @@ public class TileEntityGeneratingFlower extends TileEntitySpecialFlower {
 		//Not sure about !isBlockLoaded forcing a "false". It's more like an indeterminate result?
 		//Still, I think it's okay for these use-cases; just remember that !isValidBinding doesn't mean
 		//that you should set collectorCoordinates to `null`.
-		if (world == null || pos == null || !world.isBlockLoaded(pos) || pos.distanceSq(this.pos) > LINK_RANGE * LINK_RANGE) {
+		if (world == null || pos == null || !world.isBlockLoaded(pos) || MathHelper.distanceSq(this.pos, pos) > LINK_RANGE * LINK_RANGE) {
 			return false;
 		} else {
 			return findCollectorAt(pos) != null;

--- a/src/main/java/vazkii/botania/api/subtile/TileEntityGeneratingFlower.java
+++ b/src/main/java/vazkii/botania/api/subtile/TileEntityGeneratingFlower.java
@@ -110,6 +110,10 @@ public class TileEntityGeneratingFlower extends TileEntitySpecialFlower {
 		if (ticksExisted == 1) {
 			IManaNetwork network = BotaniaAPI.instance().getManaNetworkInstance();
 			linkedCollector = network.getClosestCollector(getPos(), getWorld(), LINK_RANGE);
+			if (linkedCollector != null) {
+				collectorCoordinates = linkedCollector.getPos();
+			}
+			markDirty();
 		}
 
 		if (collectorCoordinates != null && getWorld().isBlockLoaded(collectorCoordinates)) {

--- a/src/main/java/vazkii/botania/api/subtile/TileEntityGeneratingFlower.java
+++ b/src/main/java/vazkii/botania/api/subtile/TileEntityGeneratingFlower.java
@@ -198,8 +198,9 @@ public class TileEntityGeneratingFlower extends TileEntitySpecialFlower {
 		if (cmp.contains(TAG_COLLECTOR_X)) {
 			collectorCoordinates = new BlockPos(cmp.getInt(TAG_COLLECTOR_X), cmp.getInt(TAG_COLLECTOR_Y), cmp.getInt(TAG_COLLECTOR_Z));
 			//Older versions of the mod sometimes used this to denote an unbound collector.
-			if (collectorCoordinates.getY() == -1)
+			if (collectorCoordinates.getY() == -1) {
 				collectorCoordinates = null;
+			}
 		}
 
 		if (!Objects.equals(this.collectorCoordinates, collectorCoordinates)) {

--- a/src/main/java/vazkii/botania/api/subtile/TileEntityGeneratingFlower.java
+++ b/src/main/java/vazkii/botania/api/subtile/TileEntityGeneratingFlower.java
@@ -52,9 +52,9 @@ public class TileEntityGeneratingFlower extends TileEntitySpecialFlower {
 
 	private int mana;
 
-	protected TileEntity linkedCollector = null;
 	public int passiveDecayTicks;
 
+	private @Nullable TileEntity linkedCollector = null;
 	private @Nullable BlockPos collectorCoordinates = null;
 
 	public TileEntityGeneratingFlower(TileEntityType<?> type) {

--- a/src/main/java/vazkii/botania/api/subtile/TileEntityGeneratingFlower.java
+++ b/src/main/java/vazkii/botania/api/subtile/TileEntityGeneratingFlower.java
@@ -146,7 +146,7 @@ public class TileEntityGeneratingFlower extends TileEntitySpecialFlower {
 		//Not sure about !isBlockLoaded forcing a "false". It's more like an indeterminate result?
 		//Still, I think it's okay for these use-cases; just remember that !isValidBinding doesn't mean
 		//that you should set collectorCoordinates to `null`.
-		if (world == null || pos == null || !world.isBlockLoaded(pos) || pos.distanceSq(this.pos) > 6 * 6) {
+		if (world == null || pos == null || !world.isBlockLoaded(pos) || pos.distanceSq(this.pos) > LINK_RANGE * LINK_RANGE) {
 			return false;
 		} else {
 			return findCollectorAt(pos) != null;

--- a/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileEndoflame.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileEndoflame.java
@@ -54,30 +54,28 @@ public class SubTileEndoflame extends TileEntityGeneratingFlower {
 			return;
 		}
 
-		if (linkedCollector != null) {
-			if (burnTime == 0) {
-				if (getMana() < getMaxMana()) {
-					int slowdown = getSlowdownFactor();
+		if (burnTime == 0) {
+			if (getMana() < getMaxMana()) {
+				int slowdown = getSlowdownFactor();
 
-					for (ItemEntity item : getWorld().getEntitiesWithinAABB(ItemEntity.class, new AxisAlignedBB(getEffectivePos().add(-RANGE, -RANGE, -RANGE), getEffectivePos().add(RANGE + 1, RANGE + 1, RANGE + 1)))) {
-						int age = ((AccessorItemEntity) item).getAge();
-						if (age >= 59 + slowdown && item.isAlive()) {
-							ItemStack stack = item.getItem();
-							if (stack.isEmpty() || stack.getItem().hasContainerItem(stack)) {
-								continue;
-							}
+				for (ItemEntity item : getWorld().getEntitiesWithinAABB(ItemEntity.class, new AxisAlignedBB(getEffectivePos().add(-RANGE, -RANGE, -RANGE), getEffectivePos().add(RANGE + 1, RANGE + 1, RANGE + 1)))) {
+					int age = ((AccessorItemEntity) item).getAge();
+					if (age >= 59 + slowdown && item.isAlive()) {
+						ItemStack stack = item.getItem();
+						if (stack.isEmpty() || stack.getItem().hasContainerItem(stack)) {
+							continue;
+						}
 
-							int burnTime = getBurnTime(stack);
-							if (burnTime > 0 && stack.getCount() > 0) {
-								this.burnTime = Math.min(FUEL_CAP, burnTime) / 2;
+						int burnTime = getBurnTime(stack);
+						if (burnTime > 0 && stack.getCount() > 0) {
+							this.burnTime = Math.min(FUEL_CAP, burnTime) / 2;
 
-								stack.shrink(1);
-								getWorld().playSound(null, getEffectivePos(), ModSounds.endoflame, SoundCategory.BLOCKS, 0.2F, 1F);
-								getWorld().addBlockEvent(getPos(), getBlockState().getBlock(), START_BURN_EVENT, item.getEntityId());
-								sync();
+							stack.shrink(1);
+							getWorld().playSound(null, getEffectivePos(), ModSounds.endoflame, SoundCategory.BLOCKS, 0.2F, 1F);
+							getWorld().addBlockEvent(getPos(), getBlockState().getBlock(), START_BURN_EVENT, item.getEntityId());
+							sync();
 
-								return;
-							}
+							return;
 						}
 					}
 				}

--- a/src/main/java/vazkii/botania/common/core/handler/ConfigHandler.java
+++ b/src/main/java/vazkii/botania/common/core/handler/ConfigHandler.java
@@ -125,7 +125,6 @@ public final class ConfigHandler {
 		public final ForgeConfigSpec.BooleanValue chargingAnimationEnabled;
 		public final ForgeConfigSpec.BooleanValue silentSpreaders;
 		public final ForgeConfigSpec.IntValue spreaderTraceTime;
-		public final ForgeConfigSpec.BooleanValue flowerForceCheck;
 		public final ForgeConfigSpec.BooleanValue enderPickpocketEnabled;
 
 		public final ForgeConfigSpec.BooleanValue enchanterEnabled;
@@ -177,9 +176,6 @@ public final class ConfigHandler {
 			chargingAnimationEnabled = builder
 					.comment("Set this to false to disable the animation when an item is charging on top of a mana pool")
 					.define("chargeAnimation", true);
-			flowerForceCheck = builder
-					.comment("Turn this off ONLY IF you're on an extremely large world with an exaggerated count of Mana Spreaders/Mana Pools and are experiencing TPS lag. This toggles whether flowers are strict with their checking for connecting to pools/spreaders or just check whenever possible.")
-					.define("flowerBindingForceCheck", true);
 			enderPickpocketEnabled = builder
 					.comment("Set to false to disable the ability for the Hand of Ender to pickpocket other players' ender chests")
 					.define("enderPickpocket", true);

--- a/src/main/java/vazkii/botania/common/core/handler/ManaNetworkHandler.java
+++ b/src/main/java/vazkii/botania/common/core/handler/ManaNetworkHandler.java
@@ -16,6 +16,7 @@ import vazkii.botania.api.internal.IManaNetwork;
 import vazkii.botania.api.mana.ManaNetworkEvent;
 import vazkii.botania.api.mana.ManaNetworkEvent.Action;
 import vazkii.botania.api.mana.ManaNetworkEvent.ManaBlockType;
+import vazkii.botania.common.core.helper.MathHelper;
 
 import javax.annotation.Nullable;
 
@@ -79,7 +80,7 @@ public final class ManaNetworkHandler implements IManaNetwork {
 
 		for (TileEntity te : tiles) {
 			if (!te.isRemoved()) {
-				double distance = te.getPos().distanceSq(pos);
+				double distance = MathHelper.distanceSq(pos, te.getPos());
 				if (distance <= limit * limit && distance < minDist) {
 					minDist = distance;
 					closest = te;

--- a/src/main/java/vazkii/botania/common/core/helper/MathHelper.java
+++ b/src/main/java/vazkii/botania/common/core/helper/MathHelper.java
@@ -9,6 +9,7 @@
 package vazkii.botania.common.core.helper;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.vector.Vector3d;
 
 public final class MathHelper {
@@ -48,6 +49,14 @@ public final class MathHelper {
 		int g = (int) (g1 * (g2 / 255.0F));
 		int b = (int) (b1 * (b2 / 255.0F));
 		return c1 & ~0xFFFFFF | r << 16 | g << 8 | b;
+	}
+
+	public static int distanceSq(BlockPos a, BlockPos b) {
+		//Vanilla's BlockPos#distanceSq offsets one parameter by (0.5, 0.5, 0.5) making things get all off-center and weird.
+		int dx = a.getX() - b.getX();
+		int dy = a.getY() - b.getY();
+		int dz = a.getZ() - b.getZ();
+		return dx * dx + dy * dy + dz * dz;
 	}
 
 }

--- a/src/main/java/vazkii/botania/common/impl/BotaniaAPIImpl.java
+++ b/src/main/java/vazkii/botania/common/impl/BotaniaAPIImpl.java
@@ -32,7 +32,6 @@ import vazkii.botania.client.fx.SparkleParticleData;
 import vazkii.botania.common.Botania;
 import vazkii.botania.common.block.subtile.functional.SubTileSolegnolia;
 import vazkii.botania.common.brew.ModBrews;
-import vazkii.botania.common.core.handler.ConfigHandler;
 import vazkii.botania.common.core.handler.EquipmentHandler;
 import vazkii.botania.common.core.handler.ManaNetworkHandler;
 import vazkii.botania.common.integration.corporea.CorporeaNodeDetectors;

--- a/src/main/java/vazkii/botania/common/impl/BotaniaAPIImpl.java
+++ b/src/main/java/vazkii/botania/common/impl/BotaniaAPIImpl.java
@@ -256,11 +256,6 @@ public class BotaniaAPIImpl implements BotaniaAPI {
 		world.addParticle(data, x, y, z, 0, 0, 0);
 	}
 
-	@Override
-	public boolean shouldForceCheck() {
-		return ConfigHandler.COMMON.flowerForceCheck.get();
-	}
-
 	private final Map<ResourceLocation, Integer> legacyOreWeights = new ConcurrentHashMap<>();
 	private final Map<ResourceLocation, Integer> legacyNetherOreWeights = new ConcurrentHashMap<>();
 	private final Map<ResourceLocation, Function<DyeColor, Block>> paintableBlocks = new ConcurrentHashMap<>();

--- a/src/main/java/vazkii/botania/common/item/ItemObedienceStick.java
+++ b/src/main/java/vazkii/botania/common/item/ItemObedienceStick.java
@@ -69,7 +69,7 @@ public class ItemObedienceStick extends Item {
 
 	private static final BiFunction<TileEntitySpecialFlower, TileEntity, Boolean> generatingActuator = (flower, tile) -> {
 		if (flower instanceof TileEntityGeneratingFlower) {
-			((TileEntityGeneratingFlower) flower).linkToForcefully(tile);
+			((TileEntityGeneratingFlower) flower).setBindingForcefully(tile.getPos());
 			return true;
 		}
 		return false;

--- a/src/main/java/vazkii/botania/common/item/ItemObedienceStick.java
+++ b/src/main/java/vazkii/botania/common/item/ItemObedienceStick.java
@@ -77,7 +77,7 @@ public class ItemObedienceStick extends Item {
 
 	private static final BiFunction<TileEntitySpecialFlower, TileEntity, Boolean> functionalActuator = (flower, tile) -> {
 		if (flower instanceof TileEntityFunctionalFlower) {
-			((TileEntityFunctionalFlower) flower).linkToForcefully(tile);
+			((TileEntityFunctionalFlower) flower).setBindingForcefully(tile.getPos());
 			return true;
 		}
 		return false;


### PR DESCRIPTION
~~**Please don't merge this yet it, it's scary internal stuff and needs some more testing**~~ Yolo

This PR cleans up flower binding logic a little bit.

* `cachedCollectorCoordinates` has been renamed to just `collectorCoordinates`, and it will not be set to `null` upon the flower being unable to find a collector.
* Same for functional flowers and pools.
* The `flower.forceCheck` option has been removed, since it seems to be leftover performance snake-oil at this point: disabling `forceCheck` caused flowers to only auto-bind to the nearest pool/collector if the amount of pools/collectors in the world was different than last time it tried, but all that logic was wrapped up in a `ticksExisted == 1` block, so it'd only ever try once anyways. This PR essentially locks the option to "on".
* Direct caching of tile entities has been removed from TileEntityGeneratingFlower and TileEntityFunctionalFlower, and a call to getTileEntity is made to look up the binding each time it's used instead. This makes the `xxxCoordinates` fields the authoritative source for the flower's binding. This is - technically - worse for performance, but I think it makes better code.
* I also added something similar to PR #3789 since this PR changes the flower logic so much that that PR isn't mergable anymore.
* The Endoflame consumes fuel when not bound to a spreader now. It's the only time a flower attempted to have different behavior when bound vs. unbound (i.e. the only reason the field was `protected` instead of `private`), and dates back to 2014 - I guess it's just cruft.