### PR TITLE
Tweaks to right-click interactions with spreaders

### DIFF
--- a/src/main/java/vazkii/botania/common/block/mana/BlockSpreader.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockSpreader.java
@@ -146,9 +146,13 @@ public class BlockSpreader extends BlockModWaterloggable implements ITileEntityP
 			}
 
 			spreader.getItemHandler().setInventorySlotContents(0, heldItem.copy());
+			
+			return ActionResultType.SUCCESS;
 		} else if (!lens.isEmpty() && !wool) {
 			player.inventory.placeItemBackInInventory(player.world, lens);
 			spreader.getItemHandler().setInventorySlotContents(0, ItemStack.EMPTY);
+			
+			return ActionResultType.SUCCESS;
 		}
 
 		if (wool && spreader.paddingColor == null) {
@@ -158,14 +162,18 @@ public class BlockSpreader extends BlockModWaterloggable implements ITileEntityP
 			if (heldItem.isEmpty()) {
 				player.setHeldItem(hand, ItemStack.EMPTY);
 			}
+			
+			return ActionResultType.SUCCESS;
 		} else if (heldItem.isEmpty() && spreader.paddingColor != null && lens.isEmpty()) {
 			ItemStack pad = new ItemStack(ColorHelper.WOOL_MAP.apply(spreader.paddingColor));
 			player.inventory.placeItemBackInInventory(player.world, pad);
 			spreader.paddingColor = null;
 			spreader.markDirty();
+			
+			return ActionResultType.SUCCESS;
 		}
 
-		return ActionResultType.SUCCESS;
+		return ActionResultType.PASS;
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/mana/BlockSpreader.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockSpreader.java
@@ -158,9 +158,12 @@ public class BlockSpreader extends BlockModWaterloggable implements ITileEntityP
 		if (wool && spreader.paddingColor == null) {
 			Block block = Block.getBlockFromItem(heldItem.getItem());
 			spreader.paddingColor = ColorHelper.getWoolColor(block);
-			heldItem.shrink(1);
-			if (heldItem.isEmpty()) {
-				player.setHeldItem(hand, ItemStack.EMPTY);
+			
+			if (!player.abilities.isCreativeMode) {
+				heldItem.shrink(1);
+				if (heldItem.isEmpty()) {
+					player.setHeldItem(hand, ItemStack.EMPTY);
+				}
 			}
 			
 			return ActionResultType.SUCCESS;

--- a/src/main/java/vazkii/botania/common/block/mana/BlockSpreader.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockSpreader.java
@@ -144,37 +144,37 @@ public class BlockSpreader extends BlockModWaterloggable implements ITileEntityP
 			}
 
 			spreader.getItemHandler().setInventorySlotContents(0, heldItem.copy());
-			
+
 			return ActionResultType.SUCCESS;
 		} else if (!lens.isEmpty() && !wool) {
 			player.inventory.placeItemBackInInventory(player.world, lens);
 			spreader.getItemHandler().setInventorySlotContents(0, ItemStack.EMPTY);
-			
+
 			return ActionResultType.SUCCESS;
 		}
 
 		if (wool && spreader.paddingColor == null) {
 			Block block = Block.getBlockFromItem(heldItem.getItem());
 			spreader.paddingColor = ColorHelper.getWoolColor(block);
-			
+
 			if (!player.abilities.isCreativeMode) {
 				heldItem.shrink(1);
 				if (heldItem.isEmpty()) {
 					player.setHeldItem(hand, ItemStack.EMPTY);
 				}
 			}
-			
+
 			world.playSound(player, pos, SoundEvents.BLOCK_WOOL_PLACE, SoundCategory.BLOCKS, 1f, 1f);
-			
+
 			return ActionResultType.SUCCESS;
 		} else if (wool || heldItem.isEmpty() && spreader.paddingColor != null && lens.isEmpty()) {
 			ItemStack pad = new ItemStack(ColorHelper.WOOL_MAP.apply(spreader.paddingColor));
 			player.inventory.placeItemBackInInventory(player.world, pad);
 			spreader.paddingColor = null;
 			spreader.markDirty();
-			
+
 			world.playSound(player, pos, SoundEvents.BLOCK_WOOL_BREAK, SoundCategory.BLOCKS, 1f, 1f);
-			
+
 			return ActionResultType.SUCCESS;
 		}
 

--- a/src/main/java/vazkii/botania/common/block/mana/BlockSpreader.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockSpreader.java
@@ -22,9 +22,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.InventoryHelper;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.ActionResultType;
-import net.minecraft.util.Direction;
-import net.minecraft.util.Hand;
+import net.minecraft.util.*;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
@@ -166,12 +164,16 @@ public class BlockSpreader extends BlockModWaterloggable implements ITileEntityP
 				}
 			}
 			
+			world.playSound(player, pos, SoundEvents.BLOCK_WOOL_PLACE, SoundCategory.BLOCKS, 1f, 1f);
+			
 			return ActionResultType.SUCCESS;
 		} else if (wool || heldItem.isEmpty() && spreader.paddingColor != null && lens.isEmpty()) {
 			ItemStack pad = new ItemStack(ColorHelper.WOOL_MAP.apply(spreader.paddingColor));
 			player.inventory.placeItemBackInInventory(player.world, pad);
 			spreader.paddingColor = null;
 			spreader.markDirty();
+			
+			world.playSound(player, pos, SoundEvents.BLOCK_WOOL_BREAK, SoundCategory.BLOCKS, 1f, 1f);
 			
 			return ActionResultType.SUCCESS;
 		}

--- a/src/main/java/vazkii/botania/common/block/mana/BlockSpreader.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockSpreader.java
@@ -167,7 +167,7 @@ public class BlockSpreader extends BlockModWaterloggable implements ITileEntityP
 			}
 			
 			return ActionResultType.SUCCESS;
-		} else if (heldItem.isEmpty() && spreader.paddingColor != null && lens.isEmpty()) {
+		} else if (wool || heldItem.isEmpty() && spreader.paddingColor != null && lens.isEmpty()) {
 			ItemStack pad = new ItemStack(ColorHelper.WOOL_MAP.apply(spreader.paddingColor));
 			player.inventory.placeItemBackInInventory(player.world, pad);
 			spreader.paddingColor = null;


### PR DESCRIPTION
* Spreaders only consume right-clicks if something actually happened (adding/removing a lens, etc)
* Wool isn't removed from your inventory when decorating a spreader in creative mode.
* Wool can be removed by clicking with more wool (idk about this actually, but it makes things in creative mode easier)
* Wool makes sounds when being placed and removed.